### PR TITLE
Snapshot: Label errors as errors in the buffer

### DIFF
--- a/VisualLinter/Linting/ESLintRuleLevel.cs
+++ b/VisualLinter/Linting/ESLintRuleLevel.cs
@@ -1,0 +1,9 @@
+﻿namespace jwldnr.VisualLinter.Linting
+{
+    public class ESLintRuleLevel
+    {
+        public const int Error = 2;
+        public const int Warning = 1;
+        public const int Off = 0;
+    }
+}

--- a/VisualLinter/Linting/LinterSnapshot.cs
+++ b/VisualLinter/Linting/LinterSnapshot.cs
@@ -80,7 +80,7 @@ namespace jwldnr.VisualLinter.Linting
                     return true;
 
                 case StandardTableKeyNames.ErrorSeverity:
-                    content = GetErrorCategory(warning.Message.IsFatal);
+                    content = GetErrorCategory(warning.Message);
                     return true;
 
                 case StandardTableKeyNames.ErrorSource:
@@ -106,11 +106,19 @@ namespace jwldnr.VisualLinter.Linting
             }
         }
 
-        private static __VSERRORCATEGORY GetErrorCategory(bool isFatal)
+        private static __VSERRORCATEGORY GetErrorCategory(LinterMessage message)
         {
-            return isFatal
-                ? __VSERRORCATEGORY.EC_ERROR
-                : __VSERRORCATEGORY.EC_WARNING;
+            if (message.IsFatal)
+                return __VSERRORCATEGORY.EC_ERROR;
+
+            switch (message.Severity)
+            {
+                case ESLintRuleLevel.Error:
+                    return __VSERRORCATEGORY.EC_ERROR;
+                case ESLintRuleLevel.Warning:
+                default:
+                    return __VSERRORCATEGORY.EC_WARNING;
+            }
         }
 
         private static string GetErrorCode(bool isFatal, string ruleId)

--- a/VisualLinter/VisualLinter.csproj
+++ b/VisualLinter/VisualLinter.csproj
@@ -56,6 +56,7 @@
     <Compile Include="Helpers\OutputWindowHelper.cs" />
     <Compile Include="Helpers\VsixHelper.cs" />
     <Compile Include="Helpers\RegexHelper.cs" />
+    <Compile Include="Linting\ESLintRuleLevel.cs" />
     <Compile Include="Linting\MessageRange.cs" />
     <Compile Include="Linting\LinterMessage.cs" />
     <Compile Include="Linting\LinterResult.cs" />


### PR DESCRIPTION
Thank you for creating this Visual Studio extension for integrating ESLint.

I noticed that the extension labels all rule violations as warnings, no matter what is specified in the ESLint config. This PR adds a new feature: If the rule violation is set to be an error, it is labeled as an error in Visual Studio. 

I tried to match the style of this commit with the rest of the project. Please let me know if you would like me to make any further adjustments.